### PR TITLE
another unicode fix

### DIFF
--- a/tools/betterbib
+++ b/tools/betterbib
@@ -63,7 +63,7 @@ def _main():
             # Nothing found; write out the old entry to file.
             a = pybtex_to_bibtex_string(entry, bib_id)
             out.write(
-                '%comment{Error when fetching the following entry.}\n'
+                u'%comment{Error when fetching the following entry.}\n'
                 )
 
         out.write(a + u'\n\n')

--- a/tools/betterbib
+++ b/tools/betterbib
@@ -7,8 +7,11 @@ from io import open
 
 import collections
 from pybtex.database.input import bibtex
-import sys
 from tqdm import tqdm
+import sys
+if sys.version_info[0] == 2:
+    reload(sys)  
+    sys.setdefaultencoding('utf8')
 
 def _main():
     args = _parse_cmd_arguments()
@@ -63,8 +66,6 @@ def _main():
                 '%comment{Error when fetching the following entry.}\n'
                 )
 
-        if sys.version_info[0] == 2:
-            a = a.encode('utf8')
         out.write(a + u'\n\n')
 
     out.close()

--- a/tools/betterbib
+++ b/tools/betterbib
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
+from __future__ import unicode_literals
 import betterbib
 from betterbib import pybtex_to_bibtex_string
 from io import open
@@ -8,10 +9,6 @@ from io import open
 import collections
 from pybtex.database.input import bibtex
 from tqdm import tqdm
-import sys
-if sys.version_info[0] == 2:
-    reload(sys)  
-    sys.setdefaultencoding('utf8')
 
 def _main():
     args = _parse_cmd_arguments()
@@ -34,7 +31,7 @@ def _main():
 
     # Write header to the output file.
     out.write(
-        u'%%comment{This file was created with BetterBib v%s.}\n\n' %
+        '%%comment{This file was created with BetterBib v%s.}\n\n' %
         betterbib.__version__
         )
 
@@ -63,10 +60,10 @@ def _main():
             # Nothing found; write out the old entry to file.
             a = pybtex_to_bibtex_string(entry, bib_id)
             out.write(
-                u'%comment{Error when fetching the following entry.}\n'
+                '%comment{Error when fetching the following entry.}\n'
                 )
 
-        out.write(a + u'\n\n')
+        out.write(a + '\n\n')
 
     out.close()
     print


### PR DESCRIPTION
With betterbib 2.1.3 I was still getting an error in winPython 2.7.9:
```
Reading from: refin2.bib
Saving to: refout.bib

  0%|                                                                                            | 0/1 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "C:\Users\mthorade\Documents\Python\WinPython-32bit-2.7.9.2\python-2.7.9\Scripts\betterbib", line 99, in <module>
    _main()
  File "C:\Users\mthorade\Documents\Python\WinPython-32bit-2.7.9.2\python-2.7.9\Scripts\betterbib", line 68, in _main
    out.write(a + u'\n\n')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 43: ordinal not in range(128)
```

This seems to fix it. This time I tested in WinPython2.7.9 and WinPython 3.5
But honestly, I do not really understand what is going on.
http://stackoverflow.com/questions/21129020/how-to-fix-unicodedecodeerror-ascii-codec-cant-decode-byte