### PR TITLE
add Lyapunov to extra_names

### DIFF
--- a/betterbib/tools.py
+++ b/betterbib/tools.py
@@ -86,6 +86,7 @@ def create_dict():
         'Kuratowski',
         'Kutta',
         'Liouville',
+        'Lyapunov',
         'Magnus'
         'Manin',
         'Navier',


### PR DESCRIPTION
It would be very nice to make this configurable via a ~/.config/betterbib file or global/environmental variable.