### PR TITLE
Enable same-file editions, improve formatting

### DIFF
--- a/betterbib/tools.py
+++ b/betterbib/tools.py
@@ -184,7 +184,7 @@ def pybtex_to_bibtex_string(
 
     for key, persons in entry.persons.items():
         persons_str = ' and '.join([_get_person_str(p) for p in persons])
-        content.append(u'{} = {}{}{}'.format(key, left, persons_str, right))
+        content.append(u'{} = {}{}{}'.format(key.lower(), left, persons_str, right))
 
     keys = entry.fields.keys()
     if sort:
@@ -198,11 +198,14 @@ def pybtex_to_bibtex_string(
             # expected unicode for encode input, but got int instead
             pass
 
-        if key.lower() == 'month':
+        # Always make keys lowercase
+        key = key.lower()
+
+        if key == 'month':
             month_string = translate_month(value)
             if month_string:
                 content.append('{} = {}'.format(key, month_string))
-        elif key.lower() == 'title':
+        elif key == 'title':
             content.append(u'{} = {}{}{}'.format(
                 key, left, _translate_title(value, dictionary), right
                 ))

--- a/betterbib/tools.py
+++ b/betterbib/tools.py
@@ -312,25 +312,29 @@ def heuristic_unique_result(results, d):
 
 
 def write(od, file_handle, delimeter_type, tab_indent):
-    # Write header to the output file.
-    file_handle.write(
-        '%comment{{This file was created with betterbib v{}.}}\n\n'
-        .format(__version__)
-        )
-
     # Create the dictionary only once
     dictionary = create_dict()
 
-    # write the data out sequentially to respect ordering
-    for bib_id, d in od.items():
-        brace_delimeters = delimeter_type == 'braces'
-        a = pybtex_to_bibtex_string(
+    # Write header to the output file.
+    segments = [
+        '%comment{{This file was created with betterbib v{}.}}\n\n'
+        .format(__version__)
+    ]
+
+    brace_delimeters = delimeter_type == 'braces'
+
+    # Add segments for each bibtex entry in order
+    segments.extend([
+        pybtex_to_bibtex_string(
             d, bib_id, brace_delimeters=brace_delimeters,
             tab_indent=tab_indent,
             dictionary=dictionary,
-            )
-        file_handle.write(a + '\n\n')
-    return
+        )
+        for bib_id, d in od.items()
+    ])
+
+    # Write all segments to the file at once
+    file_handle.write('\n\n'.join(segments) + '\n')
 
 
 def update(entry1, entry2):

--- a/tools/betterbib
+++ b/tools/betterbib
@@ -22,4 +22,16 @@ while getopts ':h:' option; do
 done
 shift $((OPTIND - 1))
 
-betterbib-sync "$1" | betterbib-journal-abbrev | betterbib-format -b - "$2"
+if [[ $1 == $2 ]]
+then
+    DEST=`mktemp /tmp/betterbib.XXXXXX`
+else
+    DEST=$2
+fi
+
+betterbib-sync "$1" | betterbib-journal-abbrev | betterbib-format -b - "$DEST"
+
+if [[ $1 == $2 ]]
+then
+    mv $DEST $2
+fi


### PR DESCRIPTION
Thanks for a lovely tool! Here are couple of improvements of mine:

* betterbib can now handle the same input/output argument

This is useful when tracking your LaTeX files in a git repository, you don't need to output to a different file to compare the changes, simple `git diff` does that for you.

* Lowercase all keys in the entries

It looks better to be consistent. Betterbib always generates lowercased keys, now it also converts existing entries with uppercase keys to lowercase.

* Single file write operation, no trailing lines

Improves performance and does not output empty trailing line at the end of the file.

---- 

if you only wish to merge a portion of the changes, let me know and I will submit a separate pull request.