### PR TITLE
Use Bourne again shell

### DIFF
--- a/tools/betterbib
+++ b/tools/betterbib
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 usage="Usage: $(basename "$0") in.bib out.bib
 


### PR DESCRIPTION
It seems the script needs bash:
```
$ betterbib prshMR.bib prshMR1.bib 
/home/jan/.local/bin/betterbib: 25: /home/jan/.local/bin/betterbib: [[: not found
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 157/157 [00:21<00:00,  7.27it/s]
/home/jan/.local/bin/betterbib: 34: /home/jan/.local/bin/betterbib: [[: not found
```