### PR TITLE
Option for custom abbreviation file

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,17 +86,15 @@ for options.
 To use custom abbrebiations for journal names, create a file as a JSON
 dictionary, and provide that as a command line argument with 
 `--extra-abbrev-file`. For example, if the file `correct_pnas.json` is:
-
 ```json
 {"PNAS": "Proc. Natl. Acad. Sci.  U.S.A."}
 ```
-
 and you call `betterbib-journal-abbrev --extra-abbrev-file=correct_pnas.json`,
 this will replace any bibtex entries listed with journal "PNAS" with the
 correct abbreviation.
 
-This option is included in the `betterbib`, `betterbib-journal-abbrev`, and
-`betterbib-sync` commands.
+This option is included in the `betterbib` and `betterbib-journal-abbrev`
+commands.
 
 When combined with the `--long-journal-names` option, this will override
 default options only if both have the same abbreviation.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ betterbib-journal-abbrev in.bib out.bib
 allows you to apply consistent abbreviation of journal names. See `-h`/`--help`
 for options.
 
+#### Custom journal abbreviations
+
+To use custom abbrebiations for journal names, create a file as a JSON
+dictionary, and provide that as a command line argument with 
+`--extra-abbrev-file`. For example, if the file `correct_pnas.json` is:
+
+```json
+{"PNAS": "Proc. Natl. Acad. Sci.  U.S.A."}
+```
+
+and you call `betterbib-journal-abbrev --extra-abbrev-file=correct_pnas.json`,
+this will replace any bibtex entries listed with journal "PNAS" with the
+correct abbreviation.
+
+This option is included in the `betterbib`, `betterbib-journal-abbrev`, and
+`betterbib-sync` commands.
+
+When combined with the `--long-journal-names` option, this will override
+default options only if both have the same abbreviation.
+
 
 ### Configuration
 

--- a/betterbib/cli/full.py
+++ b/betterbib/cli/full.py
@@ -30,7 +30,7 @@ def main(argv=None):
 
     d = sync(d, args.source, args.long_journal_names, args.num_concurrent_requests)
     d = adapt_doi_urls(d, args.doi_url_type)
-    d = journal_abbrev(d, args.long_journal_names)
+    d = journal_abbrev(d, args.long_journal_names, args.extra_abbrev_file)
 
     tools.write(d, args.outfile, args.delimeter_type, tab_indent=args.tab_indent)
     return
@@ -73,6 +73,11 @@ def _get_parser():
         "--long-journal-names",
         action="store_true",
         help="prefer long journal names (default: false)",
+    )
+    parser.add_argument(
+        "--extra-abbrev-file",
+        default=None,
+        help="custom journal abbreviations, as JSON file",
     )
     parser.add_argument(
         "-c",

--- a/betterbib/cli/journal_abbrev.py
+++ b/betterbib/cli/journal_abbrev.py
@@ -18,7 +18,7 @@ def main(argv=None):
     data = bibtex.Parser().parse_file(args.infile)
     d = tools.decode(dict(data.entries.items()))
 
-    d = journal_abbrev(d, args.long_journal_names)
+    d = journal_abbrev(d, args.long_journal_names, args.extra_abbrev_file)
 
     tools.write(d, args.outfile, "braces", tab_indent=False)
     return
@@ -52,5 +52,10 @@ def _get_parser():
         "--long-journal-names",
         action="store_true",
         help="use long journal names (default: false)",
+    )
+    parser.add_argument(
+        "--extra-abbrev-file",
+        default=None,
+        help="custom journal abbreviations, as JSON file",
     )
     return parser

--- a/betterbib/journal_abbrev.py
+++ b/betterbib/journal_abbrev.py
@@ -4,10 +4,15 @@ import json
 import os
 
 
-def journal_abbrev(d, long_journal_names=False):
+def journal_abbrev(d, long_journal_names=False, custom_abbrev=None):
     this_dir = os.path.dirname(os.path.realpath(__file__))
     with open(os.path.join(this_dir, "data/journals.json"), "r") as f:
         table = json.load(f)
+
+    if custom_abbrev is not None:
+        with open(custom_abbrev) as f:
+            custom_table = json.load(f)
+        table.update(custom_table)
 
     if long_journal_names:
         table = {v: k for k, v in table.items()}

--- a/betterbib/journal_abbrev.py
+++ b/betterbib/journal_abbrev.py
@@ -12,14 +12,19 @@ def journal_abbrev(d, long_journal_names=False, custom_abbrev=None):
     if custom_abbrev is not None:
         with open(custom_abbrev) as f:
             custom_table = json.load(f)
-        table.update(custom_table)
+    else:
+        custom_table = {}
 
     if long_journal_names:
+        custom_table = {v: k for k, v in table.items()}
         table = {v: k for k, v in table.items()}
+
+    table.update(custom_table)
+    table = {k.lower(): v for k, v in table.items()}
 
     for value in d.values():
         try:
-            value.fields["journal"] = table[value.fields["journal"]]
+            value.fields["journal"] = table[value.fields["journal"].lower()]
         except KeyError:
             pass
 

--- a/betterbib/journal_abbrev.py
+++ b/betterbib/journal_abbrev.py
@@ -16,7 +16,7 @@ def journal_abbrev(d, long_journal_names=False, custom_abbrev=None):
         custom_table = {}
 
     if long_journal_names:
-        custom_table = {v: k for k, v in table.items()}
+        custom_table = {v: k for k, v in custom_table.items()}
         table = {v: k for k, v in table.items()}
 
     table.update(custom_table)

--- a/test/test_journal_abbrev.py
+++ b/test/test_journal_abbrev.py
@@ -6,16 +6,19 @@ from collections import namedtuple
 
 import betterbib
 
-FieldHolder = namedtuple('FieldHolder', 'fields')
+FieldHolder = namedtuple("FieldHolder", "fields")
 
 # the following are re-used in several tests
-FULL_PNAS = ("Proceedings of the National academy of Sciences "
-             "of the United States of America")
+FULL_PNAS = (
+    "Proceedings of the National academy of Sciences of the United States of America"
+)
 PNAS_ABBREV = "Proc. Natl. Acad. Sci. U.S.A."
 
-def make_fake_entry(journal, citekey='foo'):
-    contents = FieldHolder({'journal': journal})
+
+def make_fake_entry(journal, citekey="foo"):
+    contents = FieldHolder({"journal": journal})
     return {citekey: contents}
+
 
 def test_standard_abbrev():
     journals = [FULL_PNAS]
@@ -23,7 +26,8 @@ def test_standard_abbrev():
     for journal, abbrev in zip(journals, abbrevs):
         entries = make_fake_entry(journal)
         abbreviated = betterbib.journal_abbrev(entries)
-        assert abbreviated['foo'].fields['journal'] == abbrev
+        assert abbreviated["foo"].fields["journal"] == abbrev
+
 
 def test_custom_abbrev():
     infile = tempfile.NamedTemporaryFile().name
@@ -31,9 +35,9 @@ def test_custom_abbrev():
     with open(infile, "w") as f:
         f.write(super_short)
 
-    entries = make_fake_entry('PNAS')
+    entries = make_fake_entry("PNAS")
     abbreviated = betterbib.journal_abbrev(entries, custom_abbrev=infile)
-    assert abbreviated['foo'].fields['journal'] == PNAS_ABBREV
+    assert abbreviated["foo"].fields["journal"] == PNAS_ABBREV
 
     super_short = '{"' + FULL_PNAS + '": "PNAS"}'
     with open(infile, "w") as f:
@@ -41,16 +45,17 @@ def test_custom_abbrev():
 
     entries = make_fake_entry(FULL_PNAS)
     abbreviated = betterbib.journal_abbrev(entries, custom_abbrev=infile)
-    assert abbreviated['foo'].fields['journal'] == "PNAS"
+    assert abbreviated["foo"].fields["journal"] == "PNAS"
+
 
 def test_standard_abbrev_long():
     journals = [FULL_PNAS]
     abbrevs = [PNAS_ABBREV]
     for journal, abbrev in zip(journals, abbrevs):
         entries = make_fake_entry(abbrev)
-        abbreviated = betterbib.journal_abbrev(entries,
-                                               long_journal_names=True)
-        assert abbreviated['foo'].fields['journal'] == journal
+        abbreviated = betterbib.journal_abbrev(entries, long_journal_names=True)
+        assert abbreviated["foo"].fields["journal"] == journal
+
 
 def test_custom_abbrev_long():
     infile = tempfile.NamedTemporaryFile().name
@@ -59,7 +64,5 @@ def test_custom_abbrev_long():
         f.write(super_short)
 
     entries = make_fake_entry(PNAS_ABBREV)
-    abbreviated = betterbib.journal_abbrev(entries,
-                                           long_journal_names=True)
-    assert abbreviated['foo'].fields['journal'] == FULL_PNAS
-
+    abbreviated = betterbib.journal_abbrev(entries, long_journal_names=True)
+    assert abbreviated["foo"].fields["journal"] == FULL_PNAS

--- a/test/test_journal_abbrev.py
+++ b/test/test_journal_abbrev.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+import os
+import tempfile
+from collections import namedtuple
+
+import betterbib
+
+FieldHolder = namedtuple('FieldHolder', 'fields')
+
+# the following are re-used in several tests
+FULL_PNAS = ("Proceedings of the National academy of Sciences "
+             "of the United States of America")
+PNAS_ABBREV = "Proc. Natl. Acad. Sci. U.S.A."
+
+def make_fake_entry(journal, citekey='foo'):
+    contents = FieldHolder({'journal': journal})
+    return {citekey: contents}
+
+def test_standard_abbrev():
+    journals = [FULL_PNAS]
+    abbrevs = [PNAS_ABBREV]
+    for journal, abbrev in zip(journals, abbrevs):
+        entries = make_fake_entry(journal)
+        abbreviated = betterbib.journal_abbrev(entries)
+        assert abbreviated['foo'].fields['journal'] == abbrev
+
+def test_custom_abbrev():
+    infile = tempfile.NamedTemporaryFile().name
+    super_short = '{"PNAS": "' + PNAS_ABBREV + '"}'
+    with open(infile, "w") as f:
+        f.write(super_short)
+
+    entries = make_fake_entry('PNAS')
+    abbreviated = betterbib.journal_abbrev(entries, custom_abbrev=infile)
+    assert abbreviated['foo'].fields['journal'] == PNAS_ABBREV
+
+    super_short = '{"' + FULL_PNAS + '": "PNAS"}'
+    with open(infile, "w") as f:
+        f.write(super_short)
+
+    entries = make_fake_entry(FULL_PNAS)
+    abbreviated = betterbib.journal_abbrev(entries, custom_abbrev=infile)
+    assert abbreviated['foo'].fields['journal'] == "PNAS"
+
+def test_standard_abbrev_long():
+    journals = [FULL_PNAS]
+    abbrevs = [PNAS_ABBREV]
+    for journal, abbrev in zip(journals, abbrevs):
+        entries = make_fake_entry(abbrev)
+        abbreviated = betterbib.journal_abbrev(entries,
+                                               long_journal_names=True)
+        assert abbreviated['foo'].fields['journal'] == journal
+
+def test_custom_abbrev_long():
+    infile = tempfile.NamedTemporaryFile().name
+    super_short = '{"' + FULL_PNAS + ': "PNAS"}'
+    with open(infile, "w") as f:
+        f.write(super_short)
+
+    entries = make_fake_entry(PNAS_ABBREV)
+    abbreviated = betterbib.journal_abbrev(entries,
+                                           long_journal_names=True)
+    assert abbreviated['foo'].fields['journal'] == FULL_PNAS
+

--- a/test/test_journal_abbrev.py
+++ b/test/test_journal_abbrev.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-import os
 import tempfile
 from collections import namedtuple
 


### PR DESCRIPTION
This adds the ability to provide a JSON file (at command line) to supplement/override the default journal abbreviations. Three use cases:

1. A journal is missing from the built-in JSON file, and the user isn't comfortable digging around to figure out where the `journals.json` file is and how to edit it (maybe it was installed as root?)
2. User wants to use super-short abbreviations instead of the ISO standards; e.g., PNAS instead of Proc. Natl. Acad. Sci. U.S.A.
3. User just wants to use `betterbib-journal-abbrev`, but has bibtex entries that aren't full journal names (e.g., original bibtex has "PNAS" instead of "Proceedings of the National Academy of Sciences of the United States of America")

So far I've just added support to the journal-abbrev CLI (because that let me fix my own needs; a combination of use case 1 and 3). Before I add it to `sync` and `full`, and add unit tests, I thought I'd make sure the changes would be of interest and that the general approach fit with your vision.

Current implementation won't always work when combined with `-l` option, but that's easy enough to fix if you're interested in the PR. Let me know if you like the start, and I'll finish it up!

- [x] Add ability to supplelment/override journal abbreviations in `journal_abbrev` function
- [x] Add `--extra-abbrev-file` to `cli/journal_abbrev`
- [x] Add `--extra-abbrev-file` to `cli/full`
- [x] Fix so that switching from short to long names works correctly
- [x] Add section on abbreviations and custom abbrevs to `README.md`
- [x] Add tests for extra abbreviation file