### PR TITLE
Remove latex encoding in DOI and URL

### DIFF
--- a/betterbib/tools.py
+++ b/betterbib/tools.py
@@ -220,7 +220,8 @@ def pybtex_to_bibtex_string(
             pass
 
         try:
-            value = codecs.encode(value, "ulatex")
+            if key not in ["url", "doi"]:
+                value = codecs.encode(value, "ulatex")
         except TypeError:
             # expected unicode for encode input, but got int instead
             pass

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -68,3 +68,15 @@ def test_decode():
     out = betterbib.decode(d)
     assert out["wolframalphai1"].fields["url"] == url
     return
+
+
+def test_decode_doi():
+    doi = "10.1007/978-1-4615-7419-4_6"
+    d = {
+        "karwowski": pybtex.database.Entry(
+            "misc", fields=[("doi", doi), ("note", "Online; accessed 19-February-2019")]
+        )
+    }
+    out = betterbib.decode(d)
+    assert out["karwowski"].fields["doi"] == doi
+    return

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -80,3 +80,38 @@ def test_decode_doi():
     out = betterbib.decode(d)
     assert out["karwowski"].fields["doi"] == doi
     return
+
+
+def test_encode_url():
+    url = "https://www.wolframalpha.com/input/?i=integrate+from+0+to+2pi+(cos(x)+e%5E(i+*+(m+-+n)+*+x))"
+    d = {
+        "wolframalphai1": pybtex.database.Entry(
+            "misc", fields=[("url", url), ("note", "Online; accessed 19-February-2019")]
+        )
+    }
+
+    out = betterbib.pybtex_to_bibtex_string(d["wolframalphai1"], "wolframalphai1")
+
+    # Split string and fetch entry with url
+    url_entry = out.split()[3]
+    # Remove braces and trailing comma
+    url_entry = url_entry[1:-2]
+    assert url_entry == url
+    return
+
+
+def test_encode_doi():
+    doi = "10.1007/978-1-4615-7419-4_6"
+    d = {
+        "karwowski": pybtex.database.Entry(
+            "misc", fields=[("doi", doi), ("note", "Online; accessed 19-February-2019")]
+        )
+    }
+    out = betterbib.pybtex_to_bibtex_string(d["karwowski"], "karwowski")
+
+    # Split string and fetch entry with doi
+    doi_entry = out.split()[3]
+    # Remove braces and trailing comma
+    doi_entry = doi_entry[1:-2]
+    assert doi_entry == doi
+    return


### PR DESCRIPTION
As discussed in #126 URL's are truncated if they contain the ASCII encoding for a special character. However, the problem went deeper than the usage of `betterbib.decode` which in turn uses the `latexcodec`-package in collaboration with `codecs.decode`. When constructing the bibtex string in the function `pybtex_to_bibtex_string` the function `codecs.encode` [here](https://github.com/nschloe/betterbib/blob/master/betterbib/tools.py#L223) inserts a `\` in front of special characters such as `_`. This destroyed the DOI and the URL if they contained these characters. By checking if the key of the entry is `url` or `doi` and skipping the encoding step, this problem seems to be fixed. I've added two tests of this (and an extra test for the DOI in the decoding step) which passes.

An extra note, two of the tests seem to fail (`test_bibtex_title.py:test` and `test_crossref.py:test_crossref_book1`) prior to me doing any changes.