### PR TITLE
DBLP fix for single authors

### DIFF
--- a/betterbib/dblp.py
+++ b/betterbib/dblp.py
@@ -85,9 +85,17 @@ def _dblp_to_pybtex(data):
         fields_dict["title"] = title
 
     try:
+        # [{'@pid': '...', 'text': '...'}, ...]
         persons = {
             "author": [
                 pybtex.database.Person(au["text"]) for au in data["authors"]["author"]
+            ]
+        }
+    except TypeError:
+        # {'@pid': '...', 'text': '...'}
+        persons = {
+            "author": [
+                pybtex.database.Person(data["authors"]["author"]["text"])
             ]
         }
     except (KeyError, pybtex.database.InvalidNameString):

--- a/betterbib/dblp.py
+++ b/betterbib/dblp.py
@@ -85,19 +85,10 @@ def _dblp_to_pybtex(data):
         fields_dict["title"] = title
 
     try:
-        # [{'@pid': '...', 'text': '...'}, ...]
-        persons = {
-            "author": [
-                pybtex.database.Person(au["text"]) for au in data["authors"]["author"]
-            ]
-        }
-    except TypeError:
-        # {'@pid': '...', 'text': '...'}
-        persons = {
-            "author": [
-                pybtex.database.Person(data["authors"]["author"]["text"])
-            ]
-        }
+        authors = data["authors"]["author"]
+        if isinstance(authors, dict):
+            authors = [authors]
+        persons = {"author": [pybtex.database.Person(au["text"]) for au in authors]}
     except (KeyError, pybtex.database.InvalidNameString):
         persons = None
 


### PR DESCRIPTION
In some cases, `data["authors"]["author"]` is directly an author, instead of a list of authors:
```python
{
    'authors': {'author': {'@pid': '26/2599',
                'text': 'Kevin P. Murphy'}},
    'title': 'Machine learning - a probabilistic perspective.',
    'venue': 'Adaptive computation and machine learning series',
    'pages': 'I-XXIX, 1-1067',
    'publisher': 'MIT Press',
    'year': '2012',
    'type': 'Books and Theses',
    'key': 'books/lib/Murphy12',
    'url': 'https://dblp.org/rec/books/lib/Murphy12',
}
```

The code is a bit redundant, there may be a better way.  
Thanks for this very useful utility!