### PR TITLE
Specify minimal required version of rich

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     pyenchant
     requests
     requests_cache
-    rich
+    rich >= 9.4.0
     unidecode
 python_requires = >=3.7
 


### PR DESCRIPTION
`betterbib` requires `disable` keyword of `rich.progress.track` which was added by https://github.com/willmcgugan/rich/commit/f018047c250f1567def2caefbb0c5009ab8ad412
Thus, we need at least version 9.4.0 of `rich`.