### PR TITLE
Change behavior of `--drop` argument for betterbib format.

### DIFF
--- a/src/betterbib/cli/_format.py
+++ b/src/betterbib/cli/_format.py
@@ -35,7 +35,6 @@ def add_args(parser):
 
     parser.add_argument(
         "--drop",
-        nargs="+",
-        default=[],
-        help="Drops fields from bibtex entry if they exist.",
+        action="append",
+        help="drops field from bibtex entry if they exist, can be passed multiple times",
     )


### PR DESCRIPTION
When specifying the `--drop` argument as the last argument before the actual input files, all inputfiles are understood as fields to drop. This is particularly annoying when using betterbib as a pre-commit hook when one does not want to add another argument like `-b` between the fields to drop and the input files.

This change requires each field to drop to be passed individually using
`--drop`, e.g. `betterbib -i --drop url --drop file test.bib`.

Maybe there are better ways to do so. If you have any better ideas, please let me know as I would happily implement them. I just want the pre-commit hook to work :wink: 